### PR TITLE
添加DNS覆写功能

### DIFF
--- a/.github/workflows/manual-docker-publish.yml
+++ b/.github/workflows/manual-docker-publish.yml
@@ -1,0 +1,42 @@
+name: Manual Docker Build
+
+on:
+  workflow_dispatch: # 允许手动点击 "Run workflow" 触发
+    inputs:
+      tag:
+        description: 'Docker image tag'
+        required: true
+        default: 'latest'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # 允许推送镜像到 GitHub Packages
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }} # 自动生成的 Token，无需手动配置 Secret
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          # 镜像会存放在你的 GitHub 仓库下，路径为: ghcr.io/你的用户名/你的仓库名:标签
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.event.inputs.tag }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/manual-docker-publish.yml
+++ b/.github/workflows/manual-docker-publish.yml
@@ -29,6 +29,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }} # 自动生成的 Token，无需手动配置 Secret
 
+      - name: Prepare image name
+        run: |
+          echo "IMAGE_NAME=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
@@ -36,7 +40,7 @@ jobs:
           push: true
           # 镜像会存放在你的 GitHub 仓库下，路径为: ghcr.io/你的用户名/你的仓库名:标签
           tags: |
-            ghcr.io/${{ github.repository }}:${{ github.event.inputs.tag }}
+            ghcr.io/${{ env.IMAGE_NAME }}:${{ github.event.inputs.tag }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,10 @@ services:
       # Dashboard 登录密钥（会自动注入到配置文件中）
       # - SECRET=your-secret-here
       # TUN 模式开关（同时需要取消下方 cap_add 和 devices 的注释）
-      # - TUN_ENABLED=true
+      - TUN_ENABLED=true
+      # DNS 覆写开关
+      - DNS_OVERRIDE=true
+
 
     # 如果需要 TUN 模式，取消下面的注释
     # cap_add:

--- a/start.sh
+++ b/start.sh
@@ -278,39 +278,44 @@ EOF
         log_info "✅ tun 模式已启用"
     else
         cat >> "${config}" << 'EOF'
-tun:
-  enable: false
-EOF
-        log_info "✅ tun 模式已禁用"
+    tun:
+    enable: false
+    EOF
+        log_info "✅ tun 模式已显式关闭"
     fi
-}
+    }
 
-# 注入 DNS 覆写配置
-inject_dns() {
+    # 注入 DNS 覆写配置
+    inject_dns() {
     local config="$1"
     local dns_override="$2"
+
     [ "$dns_override" != "true" ] && return 0
+
     log_info "🔗 正在覆写配置文件中的 DNS 配置..."
+
+    # 移除现有的 dns 配置块
     local temp_file=$(mktemp)
     awk '/^dns:/{skip=1; next} skip && /^[a-zA-Z]/{skip=0} !skip{print}' "${config}" > "${temp_file}"
     cp -f "${temp_file}" "${config}"
     rm -f "${temp_file}"
+
     cat >> "${config}" << 'EOF'
-dns:
-  enable: true
-  listen: 0.0.0.0:1053
-  ipv6: false
-  enhanced-mode: fake-ip
-  fake-ip-range: 198.18.0.1/16
-  nameserver:
+    dns:
+    enable: true
+    listen: 0.0.0.0:1053
+    ipv6: false
+    enhanced-mode: fake-ip
+    fake-ip-range: 198.18.0.1/16
+    nameserver:
     - 223.5.5.5
     - 119.29.29.29
-  fallback:
+    fallback:
     - https://dns.cloudflare.com/dns-query
     - https://dns.google/dns-query
-EOF
+    EOF
     log_info "✅ DNS 配置已覆写"
-}
+    }
 
 
 # 更新配置文件中的 allow-lan
@@ -425,6 +430,7 @@ update_subscription() {
 
         # 注入 tun 配置
         inject_tun "${CONFIG_FILE}" "${TUN_ENABLED}"
+        inject_dns "${CONFIG_FILE}" "${DNS_OVERRIDE}"
         
         # 确保 external-controller 配置正确
         ensure_external_controller "${CONFIG_FILE}"
@@ -465,6 +471,7 @@ SUB_URL=${SUB_URL}
 SECRET=${SECRET}
 ALLOW_LAN=${ALLOW_LAN}
 TUN_ENABLED=${TUN_ENABLED}
+DNS_OVERRIDE=${DNS_OVERRIDE}
 SUB_USER_AGENT=${SUB_USER_AGENT}
 ${cron_schedule} /app/update_sub.sh >> /var/log/subscription.log 2>&1
 EOF
@@ -502,6 +509,7 @@ SUB_CRON=$(echo "${SUB_CRON}" | sed "s/^['\"]//;s/['\"]$//")
 DOWNLOAD_PROXY=$(echo "${DOWNLOAD_PROXY}" | sed "s/^['\"]//;s/['\"]$//")
 ALLOW_LAN=$(echo "${ALLOW_LAN}" | sed "s/^['\"]//;s/['\"]$//")
 TUN_ENABLED=$(echo "${TUN_ENABLED}" | sed "s/^['\"]//;s/['\"]$//")
+DNS_OVERRIDE=$(echo "${DNS_OVERRIDE}" | sed "s/^['\"]//;s/['\"]$//")
 SUB_USER_AGENT=$(echo "${SUB_USER_AGENT}" | sed "s/^['\"]//;s/['\"]$//")
 
 # 确保配置目录存在
@@ -548,6 +556,7 @@ if [ -n "${SUB_URL}" ]; then
             ensure_unified_delay_and_tcp_concurrent "${CONFIG_FILE}"
             # 注入 tun 配置
             inject_tun "${CONFIG_FILE}" "${TUN_ENABLED}"
+        inject_dns "${CONFIG_FILE}" "${DNS_OVERRIDE}"
             ensure_external_controller "${CONFIG_FILE}"
             
             if start_mihomo; then
@@ -596,6 +605,7 @@ if [ -n "${SUB_URL}" ]; then
         ensure_unified_delay_and_tcp_concurrent "${CONFIG_FILE}"
         # 注入 tun 配置
         inject_tun "${CONFIG_FILE}" "${TUN_ENABLED}"
+        inject_dns "${CONFIG_FILE}" "${DNS_OVERRIDE}"
         ensure_external_controller "${CONFIG_FILE}"
         
         # 启动或重启 mihomo
@@ -643,6 +653,7 @@ if [ -n "${SUB_URL}" ]; then
         
         # 注入 tun 配置
         inject_tun "${CONFIG_FILE}" "${TUN_ENABLED}"
+        inject_dns "${CONFIG_FILE}" "${DNS_OVERRIDE}"
         
         # 确保 external-controller 配置正确
         ensure_external_controller "${CONFIG_FILE}"

--- a/start.sh
+++ b/start.sh
@@ -285,6 +285,34 @@ EOF
     fi
 }
 
+# 注入 DNS 覆写配置
+inject_dns() {
+    local config="$1"
+    local dns_override="$2"
+    [ "$dns_override" != "true" ] && return 0
+    log_info "🔗 正在覆写配置文件中的 DNS 配置..."
+    local temp_file=$(mktemp)
+    awk '/^dns:/{skip=1; next} skip && /^[a-zA-Z]/{skip=0} !skip{print}' "${config}" > "${temp_file}"
+    cp -f "${temp_file}" "${config}"
+    rm -f "${temp_file}"
+    cat >> "${config}" << 'EOF'
+dns:
+  enable: true
+  listen: 0.0.0.0:1053
+  ipv6: false
+  enhanced-mode: fake-ip
+  fake-ip-range: 198.18.0.1/16
+  nameserver:
+    - 223.5.5.5
+    - 119.29.29.29
+  fallback:
+    - https://dns.cloudflare.com/dns-query
+    - https://dns.google/dns-query
+EOF
+    log_info "✅ DNS 配置已覆写"
+}
+
+
 # 更新配置文件中的 allow-lan
 update_allow_lan() {
     local config="$1"

--- a/start.sh
+++ b/start.sh
@@ -304,15 +304,17 @@ EOF
 dns:
   enable: true
   listen: 0.0.0.0:1053
-  ipv6: false
+  default-nameserver:
+    - 223.5.5.5
+    - 1.1.1.1
   enhanced-mode: fake-ip
   fake-ip-range: 198.18.0.1/16
+  fake-ip-filter:
+    - "*.lan"
+    - "*.localhost"
   nameserver:
-    - 223.5.5.5
-    - 119.29.29.29
-  fallback:
-    - https://dns.cloudflare.com/dns-query
-    - https://dns.google/dns-query
+    - https://dns.alidns.com/dns-query
+    - https://doh.pub/dns-query
 EOF
     log_info "✅ DNS 配置已覆写"
     }

--- a/start.sh
+++ b/start.sh
@@ -278,9 +278,9 @@ EOF
         log_info "✅ tun 模式已启用"
     else
         cat >> "${config}" << 'EOF'
-    tun:
-    enable: false
-    EOF
+tun:
+  enable: false
+EOF
         log_info "✅ tun 模式已显式关闭"
     fi
     }
@@ -301,19 +301,19 @@ EOF
     rm -f "${temp_file}"
 
     cat >> "${config}" << 'EOF'
-    dns:
-    enable: true
-    listen: 0.0.0.0:1053
-    ipv6: false
-    enhanced-mode: fake-ip
-    fake-ip-range: 198.18.0.1/16
-    nameserver:
+dns:
+  enable: true
+  listen: 0.0.0.0:1053
+  ipv6: false
+  enhanced-mode: fake-ip
+  fake-ip-range: 198.18.0.1/16
+  nameserver:
     - 223.5.5.5
     - 119.29.29.29
-    fallback:
+  fallback:
     - https://dns.cloudflare.com/dns-query
     - https://dns.google/dns-query
-    EOF
+EOF
     log_info "✅ DNS 配置已覆写"
     }
 

--- a/start.sh
+++ b/start.sh
@@ -300,21 +300,62 @@ EOF
     cp -f "${temp_file}" "${config}"
     rm -f "${temp_file}"
 
+# 精简版
+# dns:
+#   enable: true
+#   listen: 0.0.0.0:1053
+#   default-nameserver:
+#     - 223.5.5.5
+#     - 1.1.1.1
+#   enhanced-mode: fake-ip
+#   fake-ip-range: 198.18.0.1/16
+#   fake-ip-filter:
+#     - "*.lan"
+#     - "*.localhost"
+#   nameserver:
+#     - https://dns.alidns.com/dns-query
+#     - https://doh.pub/dns-query
+
     cat >> "${config}" << 'EOF'
 dns:
   enable: true
-  listen: 0.0.0.0:1053
+  listen: "0.0.0.0:1053"
+  prefer-h3: true
+  use-hosts: true
+  use-system-hosts: true
+  respect-rules: false
+  ipv6: true
   default-nameserver:
-    - 223.5.5.5
-    - 1.1.1.1
-  enhanced-mode: fake-ip
-  fake-ip-range: 198.18.0.1/16
+    - "223.5.5.5"
+  enhanced-mode: "fake-ip"
+  fake-ip-range: "198.18.0.1/16"
   fake-ip-filter:
     - "*.lan"
-    - "*.localhost"
+    - "localhost.ptlogin2.qq.com"
+  nameserver-policy:
+    www.baidu.com: "114.114.114.114"
+    +.internal.crop.com: "10.0.0.1"
+    geosite:cn: "https://doh.pub/dns-query"
   nameserver:
-    - https://dns.alidns.com/dns-query
-    - https://doh.pub/dns-query
+    - "https://doh.pub/dns-query"
+    - "https://dns.alidns.com/dns-query"
+    - "system://"
+  fallback:
+    - "tls://8.8.4.4"
+    - "tls://1.1.1.1"
+  proxy-server-nameserver:
+    - "https://doh.pub/dns-query"
+  fallback-filter:
+    geoip: true
+    geoip-code: "CN"
+    geosite:
+      - "gfw"
+    ipcidr:
+      - "240.0.0.0/4"
+    domain:
+      - "+.google.com"
+      - "+.facebook.com"
+      - "+.youtube.com"
 EOF
     log_info "✅ DNS 配置已覆写"
     }


### PR DESCRIPTION
<img width="412" height="100" alt="截屏2026-05-10 12 48 50" src="https://github.com/user-attachments/assets/d0d31f2c-8f40-4a0b-8e7f-b30f3c4e7bd7" />
创建镜像的时候，环境里面可以添加DNS标签：
`DNS_OVERRIDE=true`

注：
此功能仅针对不含DNS规则内容的Clash订阅链接。比如用户通过转换脚本之后只有规则和节点信息的那种订阅链接